### PR TITLE
Update database platform and allowed hosts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
 
   uway_database:
     image: postgis/postgis
+    platform: linux/amd64
     restart: always
     volumes:
       - uway_db_data:/var/lib/postgresql/data
@@ -24,6 +25,7 @@ services:
         POSTGRES_DB: ${POSTGRES_DB}
   redis:
     image: redis:alpine
+    platform: linux/amd64
     ports:
       - "6379:6379"
 

--- a/uway_backend/settings.py
+++ b/uway_backend/settings.py
@@ -30,9 +30,11 @@ SECRET_KEY = os.environ.get("SECRET_KEY", 'django-insecure-8i9+wo-@(@p9u%e5g*s7j
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
-
-
+ALLOWED_HOSTS = [
+    'localhost',
+    '127.0.0.1',
+    '192.0.0.0' # Replace with your actual host
+]
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
Update database platform to specify Linux and add allowed hosts in settings, in order to be able to connect the mobile app to the backend, it is necessary to include your computer IP to ALLOWED_HOSTS since localhost for the mobile device or simulator would point to the device itself.